### PR TITLE
Fix IE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -890,10 +890,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.9.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.6.tgz",
-      "integrity": "sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==",
-      "dev": true,
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.1.tgz",
+      "integrity": "sha512-nQbbCbQc9u/rpg1XCxoMYQTbSMVZjCDxErQ1ClCn9Pvcmv1lGads19ep0a2VsEiIJeHqjZley6EQGEC3Yo1xMA==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -4584,8 +4583,7 @@
     "regenerator-runtime": {
       "version": "0.13.5",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
-      "dev": true
+      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
     },
     "regenerator-transform": {
       "version": "0.14.4",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "sapper dev",
     "build": "sapper build --legacy",
+    "build:dev": "npm run build && npm run start",
     "export": "sapper export --legacy",
     "start": "node __sapper__/build",
     "cy:run": "cypress run",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lint:css": "stylelint \"src/**/*.{svelte,css}\""
   },
   "dependencies": {
+    "@babel/runtime": "7.10.1",
     "bootstrap": "4.5.0",
     "compression": "1.7.4",
     "normalize.css": "8.0.1",
@@ -30,7 +31,6 @@
     "@babel/plugin-syntax-dynamic-import": "7.8.3",
     "@babel/plugin-transform-runtime": "7.9.6",
     "@babel/preset-env": "7.9.6",
-    "@babel/runtime": "7.9.6",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-node-resolve": "7.1.3",
     "@rollup/plugin-replace": "2.3.2",
@@ -62,6 +62,8 @@
   "browserslist": [
     "last 2 chrome versions",
     "last 2 firefox versions",
+    "last 2 edge versions",
+    "last 1 samsung version",
     "Firefox ESR",
     "Android >= 5.0",
     "iOS >= 11",
@@ -74,9 +76,15 @@
       "stylelint-csstree-validator"
     ],
     "rules": {
-      "plugin/no-unsupported-browser-features": [true, {
-        "ignore": ["flexbox", "outline"]
-      }],
+      "plugin/no-unsupported-browser-features": [
+        true,
+        {
+          "ignore": [
+            "flexbox",
+            "outline"
+          ]
+        }
+      ],
       "csstree/validator": true
     },
     "defaultSeverity": "error"

--- a/src/components/CodeEditor.svelte
+++ b/src/components/CodeEditor.svelte
@@ -1,7 +1,8 @@
 <script>
-  import Prism from "prismjs";
-  import "prismjs/components/prism-kotlin";
-  import "prismjs/components/prism-swift";
+  // import Prism from "prismjs";
+  // import "prismjs/components/prism-kotlin";
+  // import "prismjs/components/prism-swift";
+  // TODO: Fix browser issues with importing PrismJS on IE11/Edge
 
   export let codeTabs = [];
 
@@ -10,22 +11,23 @@
   let showTooltip = false;
 
   function renderCode(language, content) {
-    let langDef;
-    switch (language) {
-      case "javascript":
-        langDef = Prism.languages.javascript;
-        break;
-      case "kotlin":
-        langDef = Prism.languages.kotlin;
-        break;
-      case "swift":
-        langDef = Prism.languages.swift;
-        break;
-      default:
-        langDef = Prism.languages.javascript;
-        break;
-    }
-    return Prism.highlight(content, langDef, language);
+    // let langDef;
+    // switch (language) {
+    //   case "javascript":
+    //     langDef = Prism.languages.javascript;
+    //     break;
+    //   case "kotlin":
+    //     langDef = Prism.languages.kotlin;
+    //     break;
+    //   case "swift":
+    //     langDef = Prism.languages.swift;
+    //     break;
+    //   default:
+    //     langDef = Prism.languages.javascript;
+    //     break;
+    // }
+    // return Prism.highlight(content, langDef, language);
+    return content;
   }
 
   $: codeHtmlOutput = renderCode(currLanguage, currTab.content);


### PR DESCRIPTION
Temporary fix for https://github.com/SkygearIO/auth-landing/issues/55. Removes the PrismJS import in CodeEditor.svelte which disables syntax highlighting and also resolves the error in Edge/IE.